### PR TITLE
Changes to script to only allow it to run on pages where it's necessary.

### DIFF
--- a/NoShitEmpornium.user.js
+++ b/NoShitEmpornium.user.js
@@ -4,16 +4,11 @@
 // @version      1.4
 // @description  Hides torrents with specified tags or by specified uploaders on Empornium
 // @author       ceodoe
-// @match        *://*.empornium.me/torrents.php*
-// @match        *://*.empornium.me/top10.php*
-// @match        *://*.empornium.me/collages.php*
-// @match        *://*.empornium.sx/torrents.php*
-// @match        *://*.empornium.sx/top10.php*
-// @match        *://*.empornium.sx/collages.php*
-// @exclude      *://*.empornium.me/torrents.php?id=*
-// @exclude      *://*.empornium.me/torrents.php?type=uploaded*
-// @exclude      *://*.empornium.sx/torrents.php?id=*
-// @exclude      *://*.empornium.sx/torrents.php?type=uploaded*
+// @include      /^https?://www\.empornium\.(me|sx)/torrents\.php*/
+// @include      /^https?://www\.empornium\.(me|sx)/collages\.php\?id=*/
+// @include      /^https?://www\.empornium\.(me|sx)/top10\.php*/
+// @exclude      /^https?://www\.empornium\.(me|sx)/torrents\.php\?id=*/
+// @exclude      /^https?://www\.empornium\.(me|sx)/torrents\.php\?type=(seeding|leeching)*/
 // @run-at       document-end
 // @grant        GM_getValue
 // @grant        GM_setValue

--- a/NoShitEmpornium.user.js
+++ b/NoShitEmpornium.user.js
@@ -8,7 +8,7 @@
 // @include      /^https?://www\.empornium\.(me|sx)/collages\.php\?id=*/
 // @include      /^https?://www\.empornium\.(me|sx)/top10\.php*/
 // @exclude      /^https?://www\.empornium\.(me|sx)/torrents\.php\?id=*/
-// @exclude      /^https?://www\.empornium\.(me|sx)/torrents\.php\?type=(seeding|leeching)*/
+// @exclude      /^https?://www\.empornium\.(me|sx)/torrents\.php\?type=(seeding|leeching)/
 // @run-at       document-end
 // @grant        GM_getValue
 // @grant        GM_setValue


### PR DESCRIPTION
Summary of changes:

* Convert match to includes using regular expressions.
* Cleanup excludes and convert to regular expressions.

Excludes stop script from running on individual torrent pages themselves and also seeding / leeching lists of a user.

The script should still run on `torrents.php?uploaded=` however since you might be looking at the uploads of someone other than yourself..